### PR TITLE
Make more portable the finding of the 'DAQ' cmake file

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -12,7 +12,7 @@ include(CMakeFindDependencyMacro)
 # set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
 # include(${targets_file})
 
-list(APPEND CMAKE_MODULE_PATH ${PACKAGE_PREFIX_DIR}/lib64/cmake/daq-buildtools)
-include(${PACKAGE_PREFIX_DIR}/lib64/cmake/daq-buildtools/DAQ.cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+include(DAQ)
 
 check_required_components(@PROJECT_NAME@)


### PR DESCRIPTION
I think this is correct in any case but the coming PR to `appfwk-externals` is related.